### PR TITLE
chore: remove console logs and replace checks for closing embed iframe

### DIFF
--- a/js/payment-embed.js
+++ b/js/payment-embed.js
@@ -68,7 +68,7 @@
 	}
 
 	w.onmessage = (e) => {
-		if (e.data.includes("close")) {
+		if (e.data.startsWith("close")) {
 			// Close the iframe when this event is emitted to the parent document,
 			const fidiaIframes = document.querySelectorAll("iframe");
 			fidiaIframes.forEach((iframe) => {

--- a/js/product-embed.js
+++ b/js/product-embed.js
@@ -68,8 +68,7 @@
 	}
 
 	w.onmessage = (e) => {
-		console.log(e);
-		if (e.data.includes("close")) {
+		if (e.data.startsWith("close")) {
 			// Close the iframe when this event is emitted to the parent document,
 			const fidiaIframes = document.querySelectorAll("iframe");
 			fidiaIframes.forEach((iframe) => {


### PR DESCRIPTION
### Motivation
I found out that I had a console.log() in the product-embed.js which is not meant to be there and for some reason the .includes() method is returning an error so I converted to using .startsWith() method instead.