### PR TITLE
fix: select only fidia specific iframes when the the close button is …

### DIFF
--- a/js/payment-embed.js
+++ b/js/payment-embed.js
@@ -8,8 +8,8 @@
 	const w = window;
 	const f = d.createElement("iframe");
 
-	// f.src = "https://embed.getfidia.com/payment.html";
-	f.src = "../payment.html";
+	f.src = "https://embed.getfidia.com/payment.html";
+	// f.src = "../payment.html";
 	f.frameborder = 0;
 	f.allowtransparency = true;
 	f.style = "display:none; position: fixed; top: 0px; left: 0px; z-index: 2147483647; border: none; opacity: 1; width: 100%; height: 100%;";

--- a/js/payment-embed.js
+++ b/js/payment-embed.js
@@ -8,8 +8,8 @@
 	const w = window;
 	const f = d.createElement("iframe");
 
-	f.src = "https://embed.getfidia.com/payment.html";
-	// f.src = "../payment.html";
+	// f.src = "https://embed.getfidia.com/payment.html";
+	f.src = "../payment.html";
 	f.frameborder = 0;
 	f.allowtransparency = true;
 	f.style = "display:none; position: fixed; top: 0px; left: 0px; z-index: 2147483647; border: none; opacity: 1; width: 100%; height: 100%;";
@@ -70,7 +70,7 @@
 	w.onmessage = (e) => {
 		if (e.data.startsWith("close")) {
 			// Close the iframe when this event is emitted to the parent document,
-			const fidiaIframes = document.querySelectorAll("iframe");
+			const fidiaIframes = document.querySelectorAll("#fidia-product-embed-iframe, #fidia-embed-iframe");
 			fidiaIframes.forEach((iframe) => {
 				iframe.style.display = "none";
 			});

--- a/js/payment-embed.js
+++ b/js/payment-embed.js
@@ -68,7 +68,7 @@
 	}
 
 	w.onmessage = (e) => {
-		if (e.data.startsWith("close")) {
+		if (e.data === 'closeFidiaPaymentIframe' || e.data === 'closeFidiaProductIframe') {
 			// Close the iframe when this event is emitted to the parent document,
 			const fidiaIframes = document.querySelectorAll("#fidia-product-embed-iframe, #fidia-embed-iframe");
 			fidiaIframes.forEach((iframe) => {

--- a/js/product-embed.js
+++ b/js/product-embed.js
@@ -8,8 +8,8 @@
 	const w = window;
 	const f = d.createElement("iframe");
 
-	f.src = "https://embed.getfidia.com/product.html";
-	// f.src = "../product.html";
+	// f.src = "https://embed.getfidia.com/product.html";
+	f.src = "../product.html";4
 	f.frameborder = 0;
 	f.allowtransparency = true;
 	f.style = "display:none; position: fixed; top: 0px; left: 0px; z-index: 2147483647; border: none; opacity: 1; width: 100%; height: 100%;";
@@ -70,7 +70,7 @@
 	w.onmessage = (e) => {
 		if (e.data.startsWith("close")) {
 			// Close the iframe when this event is emitted to the parent document,
-			const fidiaIframes = document.querySelectorAll("iframe");
+			const fidiaIframes = document.querySelectorAll("#fidia-product-embed-iframe, #fidia-embed-iframe");
 			fidiaIframes.forEach((iframe) => {
 				iframe.style.display = "none";
 			});

--- a/js/product-embed.js
+++ b/js/product-embed.js
@@ -68,7 +68,7 @@
 	}
 
 	w.onmessage = (e) => {
-		if (e.data.startsWith("close")) {
+		if (e.data === "closeFidiaPaymentIframe" || e.data === "closeFidiaProductIframe") {
 			// Close the iframe when this event is emitted to the parent document,
 			const fidiaIframes = document.querySelectorAll("#fidia-product-embed-iframe, #fidia-embed-iframe");
 			fidiaIframes.forEach((iframe) => {

--- a/js/product-embed.js
+++ b/js/product-embed.js
@@ -8,8 +8,8 @@
 	const w = window;
 	const f = d.createElement("iframe");
 
-	// f.src = "https://embed.getfidia.com/product.html";
-	f.src = "../product.html";4
+	f.src = "https://embed.getfidia.com/product.html";
+	// f.src = "../product.html";
 	f.frameborder = 0;
 	f.allowtransparency = true;
 	f.style = "display:none; position: fixed; top: 0px; left: 0px; z-index: 2147483647; border: none; opacity: 1; width: 100%; height: 100%;";


### PR DESCRIPTION
…clicked

### Motivation

I noticed that because I was not being specific enough with the selectors for closing the embed widgets - I was previously selecting all iframes on the parent window and this would cause all iframes to close when the close button is clicked.


An example of where this becomes a problem is on the creator profile public page. The video player component makes use of an iframe and in cases like this, if I opened the payment/product widget and then closed it, this would cause all the video players not to display anything because I was selecting all the iframes on the page and then setting the display property as none.

The fix is to select only iframes whose ids matches any of the payment/product widget ids.